### PR TITLE
Folio support mlc routes and cleanup

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -91,6 +91,7 @@ server {
     }
 
     location /marva/dancer/ {
+        client_max_body_size 50m;
         proxy_read_timeout 3600;
         proxy_connect_timeout 3600;
         proxy_send_timeout 3600;
@@ -249,6 +250,7 @@ server {
         proxy_set_header X-real-ip $remote_addr;
         proxy_set_header X-forward-for $proxy_add_x_forwarded_for;
 
+        client_max_body_size 50m;
         proxy_read_timeout 3600;
         proxy_connect_timeout 3600;
         proxy_send_timeout 3600;

--- a/dev-docker.sh
+++ b/dev-docker.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up "$@"

--- a/example.env
+++ b/example.env
@@ -36,6 +36,18 @@ WC_SECRET=your-worldcat-secret
 LCAP_SYNC=https://your-lcap-sync-url
 RECORD_HISTORY=https://your-record-history-url
 
+# --- FOLIO (Staging) ---
+FOLIO_STAGING_URL=https://folio-staging.example.org
+FOLIO_STAGING_TENANT=your-tenant-id
+FOLIO_STAGING_USERNAME=your-username
+FOLIO_STAGING_PASSWORD=your-password
+
+# --- FOLIO (Production) ---
+FOLIO_PRODUCTION_URL=https://folio.example.org
+FOLIO_PRODUCTION_TENANT=your-tenant-id
+FOLIO_PRODUCTION_USERNAME=your-username
+FOLIO_PRODUCTION_PASSWORD=your-password
+
 # --- Scriptshifter Feedback ---
 TXL_FEEDBACK_PATH=/mail
 TXL_EMAIL_FROM="scriptshifter@your-domain.gov"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "marva-backend",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,0 @@
-{
-  "dependencies": {
-    "simple-oauth2": "^5.1.0"
-  }
-}

--- a/util-service/app.js
+++ b/util-service/app.js
@@ -22,7 +22,8 @@ const {
   createLdpRoutes,
   createAuthRoutes,
   createUsersRoutes,
-  createEventsRoutes
+  createEventsRoutes,
+  createFolioRoutes
 } = require('./routes');
 const { optionalAuth } = require('./middleware/jwtAuth');
 const { getStagingCache, getProductionCache } = require('./services/cacheService');
@@ -170,6 +171,10 @@ function createApp(options) {
   // Event log routes
   const eventsRouter = createEventsRoutes({ getDb });
   app.use('/', eventsRouter);
+
+  // FOLIO test routes
+  const folioRouter = createFolioRoutes();
+  app.use('/', folioRouter);
 
   // LDP routes (api-staging, api-production)
   // Pass getDb as a function for lazy evaluation

--- a/util-service/package-lock.json
+++ b/util-service/package-lock.json
@@ -22,6 +22,7 @@
         "shelljs": "^0.8.5",
         "simple-git": "^3.27.0",
         "simple-oauth2": "^5.1.0",
+        "tough-cookie": "^5.1.2",
         "tslib": "^2.8.1",
         "zip-a-folder": "^3.1.8"
       },
@@ -6394,6 +6395,24 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6421,6 +6440,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {

--- a/util-service/package.json
+++ b/util-service/package.json
@@ -24,6 +24,7 @@
     "shelljs": "^0.8.5",
     "simple-git": "^3.27.0",
     "simple-oauth2": "^5.1.0",
+    "tough-cookie": "^5.1.2",
     "tslib": "^2.8.1",
     "zip-a-folder": "^3.1.8"
   },

--- a/util-service/routes/folio.js
+++ b/util-service/routes/folio.js
@@ -1,0 +1,90 @@
+/**
+ * FOLIO Test Routes
+ *
+ * Quick smoke-test endpoints to verify FOLIO connectivity.
+ *   GET /folio/test/staging    - test staging connection
+ *   GET /folio/test/production - test production connection
+ */
+
+const express = require('express');
+const { requireAuth } = require('../middleware/jwtAuth');
+const { getFolioClient, MLC_NUMBER_GENERATOR } = require('../services/folioService');
+
+function createFolioRoutes() {
+  const router = express.Router();
+
+  router.get('/folio/test/:env', async (req, res) => {
+    const env = req.params.env;
+    if (env !== 'staging' && env !== 'production') {
+      return res.status(400).json({ error: 'env must be "staging" or "production"' });
+    }
+
+    try {
+      const folio = getFolioClient(env);
+      const result = await folio.get('instance-storage/instances', 'instances', { limit: 1 });
+      res.json({
+        status: 'ok',
+        env,
+        tenant: folio.tenant,
+        url: folio.url,
+        recordCount: result.length,
+        sample: result[0] ? { id: result[0].id, title: result[0].title } : null,
+      });
+    } catch (err) {
+      console.error(`[FOLIO test] ${env} error:`, err.message);
+      res.status(500).json({
+        status: 'error',
+        env,
+        error: err.message,
+      });
+    }
+  });
+
+  router.get('/folio/number-generators/:env', requireAuth, async (req, res) => {
+    const env = req.params.env;
+    if (env !== 'staging' && env !== 'production') {
+      return res.status(400).json({ error: 'env must be "staging" or "production"' });
+    }
+
+    try {
+      const folio = getFolioClient(env);
+      const params = new URLSearchParams();
+      params.append('sort', 'enabled;asc');
+      params.append('sort', 'name;asc');
+      params.append('stats', 'true');
+      params.append('perPage', '100');
+      const result = await folio.get('servint/numberGenerators', null, params);
+      res.json(result);
+    } catch (err) {
+      console.error(`[FOLIO number-generators] ${env} error:`, err.message);
+      res.status(500).json({ status: 'error', env, error: err.message });
+    }
+  });
+
+  router.get('/folio/next-mlc/:env', requireAuth, async (req, res) => {
+    const env = req.params.env;
+    if (env !== 'staging' && env !== 'production') {
+      return res.status(400).json({ error: 'env must be "staging" or "production"' });
+    }
+
+    try {
+      const folio = getFolioClient(env);
+      const { sequence } = req.query;
+      if (!sequence) {
+        return res.status(400).json({ error: 'sequence query parameter is required' });
+      }
+      const result = await folio.get('servint/numberGenerators/getNextNumber', null, {
+        sequence,
+        generator: MLC_NUMBER_GENERATOR,
+      });
+      res.json(result);
+    } catch (err) {
+      console.error(`[FOLIO next-mlc] ${env} error:`, err.message);
+      res.status(500).json({ status: 'error', env, error: err.message });
+    }
+  });
+
+  return router;
+}
+
+module.exports = { createFolioRoutes };

--- a/util-service/routes/index.js
+++ b/util-service/routes/index.js
@@ -18,6 +18,7 @@ const { createLdpRoutes } = require('./ldp');
 const { createAuthRoutes } = require('./auth');
 const { createUsersRoutes } = require('./users');
 const { createEventsRoutes } = require('./events');
+const { createFolioRoutes } = require('./folio');
 
 module.exports = {
   createAdminRoutes,
@@ -33,5 +34,6 @@ module.exports = {
   createLdpRoutes,
   createAuthRoutes,
   createUsersRoutes,
-  createEventsRoutes
+  createEventsRoutes,
+  createFolioRoutes
 };

--- a/util-service/routes/publishing.js
+++ b/util-service/routes/publishing.js
@@ -50,7 +50,7 @@ function createPublishingRoutes(options) {
       const { COLLECTIONS } = require('../db/collections');
       await db.collection(COLLECTIONS.USERS).updateOne(
         { username },
-        { $addToSet: { catIdHistory: catId } }
+        { $set: { catId }, $addToSet: { catIdHistory: catId } }
       );
     } catch (err) {
       console.error('catId history update error (non-fatal):', err.message);

--- a/util-service/services/cacheService.js
+++ b/util-service/services/cacheService.js
@@ -209,5 +209,6 @@ module.exports = {
   populateCache,
   setupChangeStream,
   initializeCaches,
-  clearCaches
+  clearCaches,
+  normalizeUser
 };

--- a/util-service/services/folioService.js
+++ b/util-service/services/folioService.js
@@ -1,0 +1,356 @@
+/**
+ * FOLIO Client Service
+ *
+ * Node.js port of key functionality from the Python FolioClient library.
+ * Supports multiple FOLIO instances (e.g. staging + production) with
+ * cookie-based authentication, automatic token refresh, retry with
+ * backoff, and paginated fetching.
+ *
+ * Usage:
+ *   const { getFolioClient } = require('./services/folioService');
+ *   const folio = getFolioClient('staging');   // or 'production'
+ *   const instances = await folio.get('/instance-storage/instances', 'instances', { query: 'title="*"', limit: 10 });
+ *   for await (const item of folio.getAll('/item-storage/items', 'items')) { ... }
+ */
+
+const got = require('got').got;
+const { CookieJar } = require('tough-cookie');
+const { config } = require('../config');
+
+// ---------------------------------------------------------------------------
+// Configuration — reads from environment via the central config object
+// ---------------------------------------------------------------------------
+
+/**
+ * Each FOLIO environment needs:
+ *   FOLIO_<ENV>_URL        – gateway/okapi base URL
+ *   FOLIO_<ENV>_TENANT     – tenant id
+ *   FOLIO_<ENV>_USERNAME   – login username
+ *   FOLIO_<ENV>_PASSWORD   – login password
+ */
+const FOLIO_ENVS = {
+  staging: {
+    url:      process.env.FOLIO_STAGING_URL,
+    tenant:   process.env.FOLIO_STAGING_TENANT,
+    username: process.env.FOLIO_STAGING_USERNAME,
+    password: process.env.FOLIO_STAGING_PASSWORD,
+  },
+  production: {
+    url:      process.env.FOLIO_PRODUCTION_URL,
+    tenant:   process.env.FOLIO_PRODUCTION_TENANT,
+    username: process.env.FOLIO_PRODUCTION_USERNAME,
+    password: process.env.FOLIO_PRODUCTION_PASSWORD,
+  },
+};
+
+const MLC_NUMBER_GENERATOR = 'mlc_2026';
+
+// Token refresh buffer — re-auth when token expires within this many ms
+const TOKEN_REFRESH_BUFFER_MS = 60_000;
+
+// Retry settings
+const MAX_RETRIES = 3;
+const RETRY_STATUS_CODES = [502, 503, 504];
+
+// ---------------------------------------------------------------------------
+// FolioClient class
+// ---------------------------------------------------------------------------
+
+class FolioClient {
+  /**
+   * @param {object} opts
+   * @param {string} opts.url       – FOLIO gateway base URL
+   * @param {string} opts.tenant    – x-okapi-tenant
+   * @param {string} opts.username  – login username
+   * @param {string} opts.password  – login password
+   */
+  constructor({ url, tenant, username, password }) {
+    if (!url || !tenant || !username || !password) {
+      throw new Error('FolioClient requires url, tenant, username, and password');
+    }
+
+    this.url = url.replace(/\/+$/, '');
+    this.tenant = tenant;
+    this.username = username;
+    this.password = password;
+
+    // Token state
+    this._accessToken = null;
+    this._accessTokenExpires = null;
+    this._cookieJar = new CookieJar();
+
+    // Shared got instance with retry + cookie support
+    this._client = got.extend({
+      prefixUrl: this.url,
+      cookieJar: this._cookieJar,
+      headers: {
+        'content-type': 'application/json',
+        'accept': 'application/json',
+        'x-okapi-tenant': this.tenant,
+      },
+      retry: {
+        limit: MAX_RETRIES,
+        statusCodes: RETRY_STATUS_CODES,
+        methods: ['GET', 'POST', 'PUT', 'DELETE'],
+      },
+      hooks: {
+        beforeRequest: [
+          async (options) => {
+            await this._ensureToken();
+            // Set cookie header — got's cookieJar handles this, but we also
+            // set the token header for APIs that read it from the header
+            if (this._accessToken) {
+              options.headers['x-okapi-token'] = this._accessToken;
+            }
+          },
+        ],
+        afterResponse: [
+          async (response, retryWithMergedOptions) => {
+            // If we get a 401, refresh token and retry once
+            if (response.statusCode === 401) {
+              this._accessToken = null;
+              this._accessTokenExpires = null;
+              await this._login();
+              return retryWithMergedOptions({
+                headers: {
+                  'x-okapi-token': this._accessToken,
+                },
+              });
+            }
+            return response;
+          },
+        ],
+      },
+    });
+
+    this._loginPromise = null;
+  }
+
+  // -------------------------------------------------------------------------
+  // Authentication
+  // -------------------------------------------------------------------------
+
+  /**
+   * Login to FOLIO and store access/refresh tokens from cookies.
+   * Uses /authn/login-with-expiry (modern FOLIO RTR flow).
+   */
+  async _login() {
+    // Deduplicate concurrent login calls
+    if (this._loginPromise) return this._loginPromise;
+
+    this._loginPromise = (async () => {
+      try {
+        // Clear stale cookies so expired refresh tokens don't cause login to 401
+        this._cookieJar = new CookieJar();
+        this._client = this._client.extend({ cookieJar: this._cookieJar });
+
+        const resp = await got.post(`${this.url}/authn/login-with-expiry`, {
+          json: { username: this.username, password: this.password },
+          headers: {
+            'content-type': 'application/json',
+            'accept': 'application/json',
+            'x-okapi-tenant': this.tenant,
+          },
+          cookieJar: this._cookieJar,
+          responseType: 'json',
+        });
+
+        const body = resp.body;
+
+        // Extract access token from cookie jar
+        const cookies = await this._cookieJar.getCookies(this.url);
+        const accessCookie = cookies.find(c => c.key === 'folioAccessToken');
+        this._accessToken = accessCookie ? accessCookie.value : null;
+
+        // Parse expiry
+        if (body.accessTokenExpiration) {
+          this._accessTokenExpires = new Date(body.accessTokenExpiration);
+        } else {
+          // Default to 10 minutes if not provided
+          this._accessTokenExpires = new Date(Date.now() + 10 * 60 * 1000);
+        }
+
+        console.log(`[FolioClient] Authenticated to ${this.tenant} at ${this.url}`);
+      } catch (err) {
+        console.error(`[FolioClient] Login failed for ${this.tenant}:`, err.message);
+        throw err;
+      } finally {
+        this._loginPromise = null;
+      }
+    })();
+
+    return this._loginPromise;
+  }
+
+  /**
+   * Ensure we have a valid (non-expired) token, refreshing if needed.
+   */
+  async _ensureToken() {
+    if (
+      !this._accessToken ||
+      !this._accessTokenExpires ||
+      Date.now() + TOKEN_REFRESH_BUFFER_MS >= this._accessTokenExpires.getTime()
+    ) {
+      await this._login();
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Core HTTP methods
+  // -------------------------------------------------------------------------
+
+  /**
+   * GET a FOLIO endpoint.
+   *
+   * @param {string} path          – e.g. '/instance-storage/instances'
+   * @param {string|null} key      – response key containing the results array
+   * @param {object|URLSearchParams} [queryParams] – query parameters (query, limit, offset, etc.)
+   * @returns {Promise<any>}       – parsed JSON (or the value at `key`)
+   */
+  async get(path, key = null, queryParams = {}) {
+    const searchParams = queryParams instanceof URLSearchParams
+      ? queryParams
+      : new URLSearchParams(Object.entries(queryParams).map(([k, v]) => [k, String(v)]));
+    const resp = await this._client.get(path.replace(/^\//, ''), {
+      searchParams,
+      responseType: 'json',
+    });
+    return key ? resp.body[key] : resp.body;
+  }
+
+  /**
+   * POST to a FOLIO endpoint.
+   *
+   * @param {string} path          – API path
+   * @param {object} payload       – JSON body
+   * @param {object} [queryParams] – query parameters
+   * @returns {Promise<any>}       – parsed JSON response
+   */
+  async post(path, payload, queryParams = {}) {
+    const resp = await this._client.post(path.replace(/^\//, ''), {
+      json: payload,
+      searchParams: queryParams,
+      responseType: 'json',
+    });
+    return resp.body;
+  }
+
+  /**
+   * PUT to a FOLIO endpoint.
+   *
+   * @param {string} path          – API path
+   * @param {object} payload       – JSON body
+   * @param {object} [queryParams] – query parameters
+   * @returns {Promise<any>}       – parsed JSON response (or null for 204)
+   */
+  async put(path, payload, queryParams = {}) {
+    const resp = await this._client.put(path.replace(/^\//, ''), {
+      json: payload,
+      searchParams: queryParams,
+      responseType: 'json',
+    });
+    return resp.body;
+  }
+
+  /**
+   * DELETE a FOLIO resource.
+   *
+   * @param {string} path          – API path
+   * @param {object} [queryParams] – query parameters
+   * @returns {Promise<any>}       – parsed JSON response (or null for 204)
+   */
+  async delete(path, queryParams = {}) {
+    const resp = await this._client.delete(path.replace(/^\//, ''), {
+      searchParams: queryParams,
+    });
+    if (resp.statusCode === 204) return null;
+    try {
+      return JSON.parse(resp.body);
+    } catch {
+      return null;
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Pagination
+  // -------------------------------------------------------------------------
+
+  /**
+   * Async generator that pages through all results for a query.
+   *
+   * @param {string} path     – API path
+   * @param {string} key      – response key for the results array
+   * @param {object} [opts]
+   * @param {string} [opts.query]  – CQL query string
+   * @param {number} [opts.limit]  – page size (default 100)
+   * @yields {object} individual records
+   *
+   * @example
+   *   for await (const item of folio.getAll('/item-storage/items', 'items')) {
+   *     console.log(item.id);
+   *   }
+   */
+  async *getAll(path, key, { query = 'cql.allRecords=1 sortBy id', limit = 100 } = {}) {
+    let offset = 0;
+
+    while (true) {
+      const results = await this.get(path, key, { query, limit, offset });
+
+      if (!results || results.length === 0) break;
+
+      for (const record of results) {
+        yield record;
+      }
+
+      if (results.length < limit) break;
+
+      offset += limit;
+    }
+  }
+
+  /**
+   * Collect all paginated results into an array.
+   * Convenience wrapper around getAll for when you want everything in memory.
+   *
+   * @param {string} path
+   * @param {string} key
+   * @param {object} [opts]
+   * @returns {Promise<Array>}
+   */
+  async getAllArray(path, key, opts = {}) {
+    const results = [];
+    for await (const record of this.getAll(path, key, opts)) {
+      results.push(record);
+    }
+    return results;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton client instances (lazy-initialized)
+// ---------------------------------------------------------------------------
+
+const _clients = {};
+
+/**
+ * Get (or create) a FolioClient for the given environment.
+ *
+ * @param {'staging'|'production'} env
+ * @returns {FolioClient}
+ */
+function getFolioClient(env) {
+  if (!_clients[env]) {
+    const envConfig = FOLIO_ENVS[env];
+    if (!envConfig || !envConfig.url) {
+      throw new Error(
+        `FOLIO ${env} not configured. Set FOLIO_${env.toUpperCase()}_URL, ` +
+        `FOLIO_${env.toUpperCase()}_TENANT, FOLIO_${env.toUpperCase()}_USERNAME, ` +
+        `FOLIO_${env.toUpperCase()}_PASSWORD in your .env`
+      );
+    }
+    _clients[env] = new FolioClient(envConfig);
+  }
+  return _clients[env];
+}
+
+module.exports = { FolioClient, getFolioClient, MLC_NUMBER_GENERATOR };

--- a/util-service/views/index.ejs
+++ b/util-service/views/index.ejs
@@ -361,29 +361,43 @@
 								return;
 							}
 							var rows = [];
+							var groupIdx = 0;
 							data.events.forEach(function(e) {
 								var ts = e.timestamp ? new Date(e.timestamp).toLocaleString() : '';
 								var isSaveRecord = e.eventType === 'SAVED_RECORD' && Array.isArray(e.metadata) && e.metadata.length > 0 && e.metadata[0] && e.metadata[0].user;
 								var saveCount = isSaveRecord ? e.metadata.length : '';
 								var detailCol = '';
 								if (isSaveRecord) {
-									detailCol = saveCount + ' save' + (saveCount===1?'':'s');
+									detailCol = '<span class="save-toggle" style="cursor:pointer; user-select:none;">&#9654; ' + saveCount + ' save' + (saveCount===1?'':'s') + '</span>';
 								} else if (e.metadata) {
 									var meta = JSON.stringify(e.metadata);
 									if (meta.length > 80) meta = meta.substring(0, 80) + '\u2026';
 									detailCol = meta;
 								}
 								var userDisplay = (e.username||'') + (e.name ? ' <span style="color:#888; font-size:0.85em;">(' + e.name + ')</span>' : '');
-								rows.push('<tr><td>' + ts + '</td><td>' + userDisplay + '</td><td>' + (e.eventType||'') + '</td><td>' + (e.region||'') + '</td><td>' + (e.eId!=null?e.eId:'') + '</td><td>' + (e.lccn!=null?e.lccn:'') + '</td><td>' + (e.instanceId||'') + '</td><td style="font-size:0.8em; max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">' + detailCol + '</td></tr>');
+								var gid = isSaveRecord ? 'save-group-' + groupIdx : '';
+								rows.push('<tr' + (isSaveRecord ? ' data-save-group="' + groupIdx + '" style="cursor:pointer;"' : '') + '><td>' + ts + '</td><td>' + userDisplay + '</td><td>' + (e.eventType||'') + '</td><td>' + (e.region||'') + '</td><td>' + (e.eId!=null?e.eId:'') + '</td><td>' + (e.lccn!=null?e.lccn:'') + '</td><td>' + (e.instanceId||'') + '</td><td style="font-size:0.8em; max-width:200px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;">' + detailCol + '</td></tr>');
 								if (isSaveRecord) {
 									e.metadata.slice().reverse().forEach(function(m) {
 										var mTime = m.time ? new Date(m.time).toLocaleString() : '';
 										var mUserDisplay = (m.user||'') + (m.name ? ' (' + m.name + ')' : '');
-										rows.push('<tr style="background:#f9f9f9; color:#666; font-size:0.85em;"><td style="padding-left:2em;">\u2514 ' + mTime + '</td><td>' + mUserDisplay + '</td><td colspan="6"></td></tr>');
+										rows.push('<tr class="save-group-' + groupIdx + '" style="display:none; background:#f9f9f9; color:#666; font-size:0.85em;"><td style="padding-left:2em;">\u2514 ' + mTime + '</td><td>' + mUserDisplay + '</td><td colspan="6"></td></tr>');
 									});
+									groupIdx++;
 								}
 							});
 							tbody.innerHTML = rows.join('');
+
+							tbody.addEventListener('click', function(evt) {
+								var row = evt.target.closest('tr[data-save-group]');
+								if (!row) return;
+								var gid = row.getAttribute('data-save-group');
+								var subRows = tbody.querySelectorAll('.save-group-' + gid);
+								var toggle = row.querySelector('.save-toggle');
+								var visible = subRows[0] && subRows[0].style.display !== 'none';
+								subRows.forEach(function(r) { r.style.display = visible ? 'none' : ''; });
+								if (toggle) toggle.innerHTML = (visible ? '&#9654; ' : '&#9660; ') + toggle.textContent.replace(/^[\u25B6\u25BC]\s*/, '');
+							});
 						})
 						.catch(function(err) {
 							tbody.innerHTML = '<tr><td colspan="8" style="color:red;">Error: ' + err.message + '</td></tr>';


### PR DESCRIPTION
- adds FOLIO API support to the backend
- which is used to now make MLC staging/prod requests
- fixed bugs and cleaned up some displays and routes
 