### PR TITLE
Deploy refactor

### DIFF
--- a/util-service/db/collections.js
+++ b/util-service/db/collections.js
@@ -59,7 +59,12 @@ const INDEXES = {
   [COLLECTIONS.FEATURE_FLAGS]: [
     { key: { type: 1, name: 1 }, name: 'type_name_index' },
     { key: { type: 1, username: 1 }, name: 'type_username_index' },
-    { key: { type: 1, feature: 1, username: 1 }, name: 'assignment_unique_index', unique: true }
+    {
+      key: { type: 1, feature: 1, username: 1 },
+      name: 'assignment_unique_index',
+      unique: true,
+      partialFilterExpression: { type: 'assignment' }
+    }
   ]
 };
 
@@ -76,15 +81,27 @@ async function ensureIndexes(db, collectionName) {
   const collection = db.collection(collectionName);
 
   for (const index of indexes) {
+    const options = {
+      name: index.name,
+      unique: index.unique || false,
+      background: true
+    };
+    if (index.partialFilterExpression) {
+      options.partialFilterExpression = index.partialFilterExpression;
+    }
     try {
-      await collection.createIndex(index.key, {
-        name: index.name,
-        unique: index.unique || false,
-        background: true
-      });
+      await collection.createIndex(index.key, options);
     } catch (err) {
-      // Index might already exist, that's OK
-      if (err.code !== 85 && err.code !== 86) {
+      // Code 85/86: an index with the same name or keys already exists with
+      // different options. Drop it and recreate to apply the new definition.
+      if (err.code === 85 || err.code === 86) {
+        try {
+          await collection.dropIndex(index.name);
+          await collection.createIndex(index.key, options);
+        } catch (recreateErr) {
+          console.error(`Error recreating index ${index.name} on ${collectionName}:`, recreateErr);
+        }
+      } else {
         console.error(`Error creating index ${index.name} on ${collectionName}:`, err);
       }
     }

--- a/util-service/routes/admin.js
+++ b/util-service/routes/admin.js
@@ -12,8 +12,10 @@
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
-const shell = require('shelljs');
+const { spawn } = require('child_process');
 const { hasDeployAuth, hasStatsAuth } = require('../config');
+
+const DEPLOY_LOG_MAX_LINES = 5000;
 
 const DEPLOY_INFO_PATH = path.join(__dirname, '..', 'deploy-info.json');
 
@@ -277,68 +279,274 @@ function createAdminRoutes(options) {
   // DEPLOY ENDPOINTS
   // ============================================
 
-  /**
-   * Execute deploy script and return HTML result
-   * @param {string} scriptPath - Path to the script
-   * @returns {string} HTML formatted output
-   */
-  function executeDeployScript(scriptPath) {
-    const r = shell.exec(scriptPath);
-    return `<h1>stdout</h1><pre><code>${r.stdout.toString()}</pre></code><hr><h1>stderr</h1><pre><code>${r.stderr.toString()}</pre></code>`;
+  // Single in-flight deploy job. Older finished jobs are kept here briefly so
+  // the UI can fetch their tail log after the page reloads, but only one job
+  // can be `running` at a time. SSE subscribers are stored on the job itself.
+  let currentDeployJob = null;
+  const finishedDeployJobs = new Map();
+  const FINISHED_JOB_RETAIN_MS = 30 * 60 * 1000;
+
+  function pruneFinishedJobs() {
+    const cutoff = Date.now() - FINISHED_JOB_RETAIN_MS;
+    for (const [id, job] of finishedDeployJobs) {
+      if (job.finishedAt && new Date(job.finishedAt).getTime() < cutoff) {
+        finishedDeployJobs.delete(id);
+      }
+    }
+  }
+
+  function getJob(jobId) {
+    if (currentDeployJob && currentDeployJob.jobId === jobId) return currentDeployJob;
+    return finishedDeployJobs.get(jobId) || null;
+  }
+
+  function pushLogLine(job, stream, line) {
+    const entry = { t: Date.now(), stream, line };
+    job.log.push(entry);
+    if (job.log.length > DEPLOY_LOG_MAX_LINES) {
+      job.log.splice(0, job.log.length - DEPLOY_LOG_MAX_LINES);
+      if (!job.logTruncated) job.logTruncated = true;
+    }
+    for (const sub of job.subscribers) {
+      try {
+        sub.write(`event: log\ndata: ${JSON.stringify(entry)}\n\n`);
+      } catch (_) { /* subscriber gone; close handler removes it */ }
+    }
   }
 
   /**
-   * GET /deploy-production - Deploy production MARVA
-   * Requires deploy authentication
+   * Start a deploy job by spawning a shell script. Returns the job object.
+   * Throws if another deploy is already in flight.
+   */
+  function startDeployJob({ target, script, args = [], branch = null, onSuccess = null }) {
+    if (currentDeployJob && currentDeployJob.status === 'running') {
+      const err = new Error('Deploy already in progress');
+      err.code = 'DEPLOY_BUSY';
+      err.runningJob = describeJob(currentDeployJob);
+      throw err;
+    }
+
+    const jobId = `${target}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const job = {
+      jobId,
+      target,
+      branch,
+      script,
+      args,
+      status: 'running',
+      exitCode: null,
+      startedAt: new Date().toISOString(),
+      finishedAt: null,
+      log: [],
+      logTruncated: false,
+      subscribers: new Set(),
+      child: null
+    };
+
+    const child = spawn(script, args, {
+      cwd: path.join(__dirname, '..'),
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe']
+    });
+    job.child = child;
+    job.pid = child.pid;
+    currentDeployJob = job;
+
+    const wireStream = (stream, name) => {
+      let buf = '';
+      stream.setEncoding('utf8');
+      stream.on('data', chunk => {
+        buf += chunk;
+        let idx;
+        while ((idx = buf.indexOf('\n')) !== -1) {
+          const line = buf.slice(0, idx);
+          buf = buf.slice(idx + 1);
+          pushLogLine(job, name, line);
+        }
+      });
+      stream.on('end', () => {
+        if (buf.length) {
+          pushLogLine(job, name, buf);
+          buf = '';
+        }
+      });
+    };
+    wireStream(child.stdout, 'stdout');
+    wireStream(child.stderr, 'stderr');
+
+    child.on('error', err => {
+      pushLogLine(job, 'stderr', `[spawn error] ${err.message}`);
+    });
+
+    child.on('close', code => {
+      job.exitCode = code;
+      job.status = code === 0 ? 'done' : 'failed';
+      job.finishedAt = new Date().toISOString();
+      job.child = null;
+      if (code === 0 && typeof onSuccess === 'function') {
+        try { onSuccess(); } catch (e) {
+          pushLogLine(job, 'stderr', `[post-deploy hook error] ${e.message}`);
+        }
+      }
+      const summary = describeJob(job);
+      for (const sub of job.subscribers) {
+        try {
+          sub.write(`event: done\ndata: ${JSON.stringify(summary)}\n\n`);
+          sub.end();
+        } catch (_) { /* ignore */ }
+      }
+      job.subscribers.clear();
+      finishedDeployJobs.set(jobId, job);
+      if (currentDeployJob && currentDeployJob.jobId === jobId) {
+        currentDeployJob = null;
+      }
+      pruneFinishedJobs();
+    });
+
+    return job;
+  }
+
+  function describeJob(job) {
+    if (!job) return null;
+    return {
+      jobId: job.jobId,
+      target: job.target,
+      branch: job.branch,
+      status: job.status,
+      exitCode: job.exitCode,
+      startedAt: job.startedAt,
+      finishedAt: job.finishedAt,
+      logTruncated: !!job.logTruncated,
+      logLines: job.log.length
+    };
+  }
+
+  /**
+   * Express helper: kick off a deploy script and return JSON. Handles 401 +
+   * 409 (busy) responses uniformly.
+   */
+  function handleDeployRequest(req, res, { target, script, args = [], branch = null, onSuccess = null }) {
+    if (!hasDeployAuth(req)) {
+      return res.set('WWW-Authenticate', 'Basic').status(401).send('Authentication required.');
+    }
+    try {
+      const job = startDeployJob({ target, script, args, branch, onSuccess });
+      res.status(200).json(describeJob(job));
+    } catch (err) {
+      if (err.code === 'DEPLOY_BUSY') {
+        return res.status(409).json({
+          error: 'Another deploy is already running',
+          running: err.runningJob
+        });
+      }
+      res.status(500).json({ error: err.message });
+    }
+  }
+
+  /**
+   * GET /deploy-production - Deploy production MARVA (async)
+   * Requires deploy authentication. Returns { jobId, ... } immediately.
    */
   router.get('/deploy-production', (req, res) => {
-    if (!hasDeployAuth(req)) {
-      return res.set('WWW-Authenticate', 'Basic').status(401).send('Authentication required.');
-    }
-    const result = executeDeployScript('./scripts/deploy-production.sh');
-    res.status(200).send(result);
+    handleDeployRequest(req, res, {
+      target: 'prod-marva',
+      script: './scripts/deploy-production.sh'
+    });
   });
 
   /**
-   * GET /deploy-production-quartz - Deploy production Quartz
-   * Requires deploy authentication
-   * Optional query param: ?branch=branch-name
+   * GET /deploy-production-quartz - Deploy production Quartz (async)
+   * Requires deploy authentication. Optional query param: ?branch=branch-name
    */
   router.get('/deploy-production-quartz', (req, res) => {
-    if (!hasDeployAuth(req)) {
-      return res.set('WWW-Authenticate', 'Basic').status(401).send('Authentication required.');
-    }
     const branch = req.query.branch || 'main';
-    const result = executeDeployScript(`./scripts/deploy-production-quartz.sh "${branch}"`);
-    writeDeployInfo('prod-quartz', branch);
-    res.status(200).send(result);
+    handleDeployRequest(req, res, {
+      target: 'prod-quartz',
+      script: './scripts/deploy-production-quartz.sh',
+      args: [branch],
+      branch,
+      onSuccess: () => writeDeployInfo('prod-quartz', branch)
+    });
   });
 
   /**
-   * GET /deploy-staging - Deploy staging MARVA
-   * Requires deploy authentication
+   * GET /deploy-staging - Deploy staging MARVA (async)
+   * Requires deploy authentication.
    */
   router.get('/deploy-staging', (req, res) => {
-    if (!hasDeployAuth(req)) {
-      return res.set('WWW-Authenticate', 'Basic').status(401).send('Authentication required.');
-    }
-    const result = executeDeployScript('./scripts/deploy-staging.sh');
-    res.status(200).send(result);
+    handleDeployRequest(req, res, {
+      target: 'stage-marva',
+      script: './scripts/deploy-staging.sh'
+    });
   });
 
   /**
-   * GET /deploy-staging-quartz - Deploy staging Quartz
-   * Requires deploy authentication
-   * Optional query param: ?branch=branch-name
+   * GET /deploy-staging-quartz - Deploy staging Quartz (async)
+   * Requires deploy authentication. Optional query param: ?branch=branch-name
    */
   router.get('/deploy-staging-quartz', (req, res) => {
+    const branch = req.query.branch || 'main';
+    handleDeployRequest(req, res, {
+      target: 'stage-quartz',
+      script: './scripts/deploy-staging-quartz.sh',
+      args: [branch],
+      branch,
+      onSuccess: () => writeDeployInfo('stage-quartz', branch)
+    });
+  });
+
+  /**
+   * GET /deploy-current - Returns the in-flight deploy job (or null).
+   * Used by the UI on page load to reattach to a running deploy.
+   */
+  router.get('/deploy-current', (req, res) => {
     if (!hasDeployAuth(req)) {
       return res.set('WWW-Authenticate', 'Basic').status(401).send('Authentication required.');
     }
-    const branch = req.query.branch || 'main';
-    const result = executeDeployScript(`./scripts/deploy-staging-quartz.sh "${branch}"`);
-    writeDeployInfo('stage-quartz', branch);
-    res.status(200).send(result);
+    res.json(describeJob(currentDeployJob));
+  });
+
+  /**
+   * GET /deploy-log/:jobId - SSE stream of a deploy job's stdout/stderr.
+   * Replays the buffered log on connect, streams new lines as they arrive,
+   * sends a final `done` event with the exit code, then closes.
+   */
+  router.get('/deploy-log/:jobId', (req, res) => {
+    if (!hasDeployAuth(req)) {
+      return res.set('WWW-Authenticate', 'Basic').status(401).send('Authentication required.');
+    }
+    const job = getJob(req.params.jobId);
+    if (!job) {
+      return res.status(404).json({ error: 'Unknown jobId' });
+    }
+
+    res.set({
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no'
+    });
+    res.flushHeaders();
+
+    res.write(`event: meta\ndata: ${JSON.stringify(describeJob(job))}\n\n`);
+    for (const entry of job.log) {
+      res.write(`event: log\ndata: ${JSON.stringify(entry)}\n\n`);
+    }
+
+    if (job.status !== 'running') {
+      res.write(`event: done\ndata: ${JSON.stringify(describeJob(job))}\n\n`);
+      return res.end();
+    }
+
+    job.subscribers.add(res);
+    const keepAlive = setInterval(() => {
+      try { res.write(': keep-alive\n\n'); } catch (_) {}
+    }, 15000);
+
+    req.on('close', () => {
+      clearInterval(keepAlive);
+      job.subscribers.delete(res);
+    });
   });
 
   /**
@@ -369,12 +577,26 @@ function createAdminRoutes(options) {
   });
 
   /**
-   * GET /deploy-profile-editor - Deploy profile editor
-   * No authentication required (matches original behavior)
+   * GET /deploy-profile-editor - Deploy profile editor (async)
+   * No authentication required (matches original behavior). Returns
+   * { jobId, ... } immediately; tail via /deploy-log/:jobId.
    */
   router.get('/deploy-profile-editor', (req, res) => {
-    const result = executeDeployScript('./scripts/deploy-profile-editor.sh');
-    res.status(200).send(result);
+    try {
+      const job = startDeployJob({
+        target: 'profile-editor',
+        script: './scripts/deploy-profile-editor.sh'
+      });
+      res.status(200).json(describeJob(job));
+    } catch (err) {
+      if (err.code === 'DEPLOY_BUSY') {
+        return res.status(409).json({
+          error: 'Another deploy is already running',
+          running: err.runningJob
+        });
+      }
+      res.status(500).json({ error: err.message });
+    }
   });
 
   return router;

--- a/util-service/views/index.ejs
+++ b/util-service/views/index.ejs
@@ -89,6 +89,39 @@
 			background-color: whitesmoke;
 			border: solid 1px lightgray;
 		}
+		#deploy-log-panel{
+			display: none;
+			margin-top: 1em;
+			border: solid 1px #999;
+			background: #111;
+			color: #eee;
+			border-radius: 4px;
+			overflow: hidden;
+		}
+		#deploy-log-panel .deploy-log-header{
+			padding: 0.5em 0.75em;
+			background: #222;
+			color: #fff;
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			font-size: 0.9em;
+		}
+		#deploy-log-panel .deploy-log-status.running{ color: #ffeb3b; }
+		#deploy-log-panel .deploy-log-status.done{ color: #8bc34a; }
+		#deploy-log-panel .deploy-log-status.failed{ color: #f44336; }
+		#deploy-log-panel pre{
+			margin: 0;
+			padding: 0.75em;
+			max-height: 22em;
+			overflow: auto;
+			font-family: ui-monospace, Menlo, monospace;
+			font-size: 0.78em;
+			line-height: 1.35;
+			white-space: pre-wrap;
+			word-break: break-word;
+		}
+		#deploy-log-panel .stderr{ color: #ff8a80; }
 		hr{
 			margin: 2em;
 		}
@@ -127,11 +160,25 @@
 			</div>
 		</div>
 
+		<div id="deploy-log-panel">
+			<div class="deploy-log-header">
+				<span>
+					<strong id="deploy-log-title">Deploy log</strong>
+					<span class="deploy-log-status" id="deploy-log-status">idle</span>
+				</span>
+				<span>
+					<button id="deploy-log-clear" type="button" style="font-size: 0.85em;">Hide</button>
+				</span>
+			</div>
+			<pre id="deploy-log-output"></pre>
+		</div>
+
 		<details style="margin-top: 1em; background-color: whitesmoke; padding: 0.5em; border: solid 1px lightgray;">
 			<summary style="cursor: pointer;">Legacy Deploy (Marva, Profile Editor)</summary>
 			<div style="margin-top: 0.5em; display: flex; gap: 0.5em; flex-wrap: wrap;">
-				<a href="deploy-staging" class="deploy" target="_blank">Deploy Marva Staging</a>
-				<a href="deploy-production" class="deploy" target="_blank">Deploy Marva Production</a>				
+				<button type="button" class="deploy" data-deploy-endpoint="deploy-staging" data-deploy-label="Marva Staging">Deploy Marva Staging</button>
+				<button type="button" class="deploy" data-deploy-endpoint="deploy-production" data-deploy-label="Marva Production">Deploy Marva Production</button>
+				<button type="button" class="deploy" data-deploy-endpoint="deploy-profile-editor" data-deploy-label="Profile Editor">Deploy Profile Editor</button>
 			</div>
 		</details>
 		<div><a href="../dancer/" style="margin-top: 1em; display: inline-block;" target="_blank">Open DCTap Dancer Editor</a></div>
@@ -191,6 +238,7 @@
 
 			// Poll deploy info every 10s until it changes, then stop
 			function pollDeployInfo(region, infoElId) {
+				if (!region || !infoElId) return;
 				const el = document.getElementById(infoElId);
 				const previousDeployed = el.dataset.deployed || '';
 				const interval = setInterval(() => {
@@ -208,21 +256,129 @@
 				}, 10000);
 			}
 
-			// Deploy buttons
+			// ----- Async deploy + SSE log viewer -----
+			const deployLogPanel = document.getElementById('deploy-log-panel');
+			const deployLogTitle = document.getElementById('deploy-log-title');
+			const deployLogStatus = document.getElementById('deploy-log-status');
+			const deployLogOutput = document.getElementById('deploy-log-output');
+			const deployLogHide = document.getElementById('deploy-log-clear');
+			let activeEventSource = null;
+
+			deployLogHide.addEventListener('click', () => {
+				deployLogPanel.style.display = 'none';
+			});
+
+			function setDeployStatus(label, kind) {
+				deployLogStatus.textContent = label;
+				deployLogStatus.className = 'deploy-log-status ' + (kind || '');
+			}
+
+			function appendLogEntry(entry) {
+				const span = document.createElement('span');
+				if (entry.stream === 'stderr') span.className = 'stderr';
+				span.textContent = (entry.line || '') + '\n';
+				const wasAtBottom = deployLogOutput.scrollHeight - deployLogOutput.scrollTop - deployLogOutput.clientHeight < 40;
+				deployLogOutput.appendChild(span);
+				if (wasAtBottom) deployLogOutput.scrollTop = deployLogOutput.scrollHeight;
+			}
+
+			function attachToJob(job, opts) {
+				opts = opts || {};
+				if (activeEventSource) {
+					try { activeEventSource.close(); } catch (_) {}
+					activeEventSource = null;
+				}
+				deployLogPanel.style.display = 'block';
+				deployLogTitle.textContent = 'Deploy log — ' + job.target + (job.branch ? ' (' + job.branch + ')' : '');
+				deployLogOutput.innerHTML = '';
+				setDeployStatus(job.status, job.status);
+
+				const es = new EventSource('deploy-log/' + encodeURIComponent(job.jobId));
+				activeEventSource = es;
+				es.addEventListener('meta', e => {
+					try {
+						const meta = JSON.parse(e.data);
+						setDeployStatus(meta.status, meta.status);
+					} catch (_) {}
+				});
+				es.addEventListener('log', e => {
+					try { appendLogEntry(JSON.parse(e.data)); } catch (_) {}
+				});
+				es.addEventListener('done', e => {
+					try {
+						const summary = JSON.parse(e.data);
+						setDeployStatus(summary.status + ' (exit ' + summary.exitCode + ')', summary.status);
+						if (summary.status === 'done' && opts.region && opts.infoElId) {
+							pollDeployInfo(opts.region, opts.infoElId);
+						}
+					} catch (_) {}
+					es.close();
+					if (activeEventSource === es) activeEventSource = null;
+				});
+				es.onerror = () => {
+					// Connection dropped; the job may still be running on the server.
+					// We don't auto-reconnect — user can reload the page to reattach.
+				};
+			}
+
+			function startDeploy(url, opts) {
+				opts = opts || {};
+				deployLogPanel.style.display = 'block';
+				deployLogTitle.textContent = 'Deploy log — starting…';
+				deployLogOutput.innerHTML = '';
+				setDeployStatus('starting', 'running');
+				fetch(url, { credentials: 'same-origin' })
+					.then(async r => {
+						const body = await r.json().catch(() => ({}));
+						if (r.status === 409 && body && body.running) {
+							alert('Another deploy is already running: ' + (body.running.target || 'unknown') + '. Attaching to it.');
+							attachToJob(body.running, opts);
+							return;
+						}
+						if (!r.ok) {
+							setDeployStatus('failed to start', 'failed');
+							appendLogEntry({ stream: 'stderr', line: '[start error] ' + (body.error || r.statusText) });
+							return;
+						}
+						attachToJob(body, opts);
+					})
+					.catch(err => {
+						setDeployStatus('failed to start', 'failed');
+						appendLogEntry({ stream: 'stderr', line: '[network error] ' + err.message });
+					});
+			}
+
+			// Deploy buttons (quartz)
 			document.getElementById('deploy-staging-quartz-btn').addEventListener('click', () => {
 				const branch = document.getElementById('staging-quartz-branch').value;
-				if (confirm('Deploy Quartz Staging with branch: ' + branch + '?')) {
-					window.open('deploy-staging-quartz?branch=' + encodeURIComponent(branch), '_blank');
-					pollDeployInfo('stage-quartz', 'staging-quartz-info');
-				}
+				if (!confirm('Deploy Quartz Staging with branch: ' + branch + '?')) return;
+				startDeploy('deploy-staging-quartz?branch=' + encodeURIComponent(branch),
+					{ region: 'stage-quartz', infoElId: 'staging-quartz-info' });
 			});
 			document.getElementById('deploy-production-quartz-btn').addEventListener('click', () => {
 				const branch = document.getElementById('production-quartz-branch').value;
-				if (confirm('Deploy Quartz Production with branch: ' + branch + '?')) {
-					window.open('deploy-production-quartz?branch=' + encodeURIComponent(branch), '_blank');
-					pollDeployInfo('prod-quartz', 'production-quartz-info');
-				}
+				if (!confirm('Deploy Quartz Production with branch: ' + branch + '?')) return;
+				startDeploy('deploy-production-quartz?branch=' + encodeURIComponent(branch),
+					{ region: 'prod-quartz', infoElId: 'production-quartz-info' });
 			});
+
+			// Legacy deploy buttons (Marva, Profile Editor)
+			document.querySelectorAll('button.deploy[data-deploy-endpoint]').forEach(btn => {
+				btn.addEventListener('click', () => {
+					const endpoint = btn.dataset.deployEndpoint;
+					const label = btn.dataset.deployLabel || endpoint;
+					if (!confirm('Deploy ' + label + '?')) return;
+					startDeploy(endpoint);
+				});
+			});
+
+			// On page load, reattach to any in-flight deploy
+			fetch('deploy-current')
+				.then(r => r.ok ? r.json() : null)
+				.then(job => {
+					if (job && job.status === 'running') attachToJob(job);
+				})
+				.catch(() => {});
 		</script>
 
 


### PR DESCRIPTION
This changes the way the deploy front-end flow works. Right now it is blocking the thread until it is complete, this causes the rest of the util-service to not respond while deployment is happening. It now does it in an async thread and polls the output. The deploy logs are displayed on the admin page now:

<img width="1316" height="512" alt="image" src="https://github.com/user-attachments/assets/728ed292-f8be-4292-b312-91b6bf7d342f" />
