### PR TITLE
add nonet

### DIFF
--- a/util-service/routes/marc.js
+++ b/util-service/routes/marc.js
@@ -20,7 +20,7 @@ const Marc = marcjs.Marc;
  */
 function runXsltproc(xsltPath, xmlContent) {
   return new Promise((resolve) => {
-    const proc = spawn('xsltproc', [xsltPath, '-']);
+    const proc = spawn('xsltproc', ['--nonet', xsltPath, '-']);
     let stdout = '';
     let stderr = '';
 


### PR DESCRIPTION
Adds the --nonet argument to xsltproc command, if it tries to look up a label it often timesout and crashes the process returning a 500 from the cloudeflare gateway. Just dont try to do the lookups live, if its not in the marckey or missing a label that is fine.